### PR TITLE
Always use forward slashes even on Windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ function plugin(options) {
         // Add fingerprinted file to files
         files[fingerprint] = files[p]
         // Add fingerprinted filename to metadata
-        metadata.fingerprint[p] = fingerprint
+        metadata.fingerprint[p.replace(/\\/g, '/')] = fingerprint.replace(/\\/g, '/')
         // Remove original, unless specified otherwise
         if (!options.keep) delete files[p]
       })


### PR DESCRIPTION
I'm building on Windows, Mac and Linux and the keys don't match between platforms. These two replaces mean that the values and keys have '\' reaplaced with '/'.